### PR TITLE
Add Codecov coverage workflow and badge

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^WikiCitationHistoRy\.Rproj$
 ^\.Rproj\.user$
+
+^\.github$

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,20 @@
+name: test-coverage
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: covr
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WikiCitationHistoRy R package
 
+[![Codecov test coverage](https://codecov.io/gh/jsobel1/WikiCitationHistoRy/branch/master/graph/badge.svg)](https://codecov.io/gh/jsobel1/WikiCitationHistoRy?branch=master)
+
 WikiCitationHistoRy was developed in order to retrieve the history and its content of any wikipedia article as timestamps, revision ID , users, article size,and article text. This package allows retrieval of all information in structured tables and provides several visualisations of the data. In addition, the package offers several options to extract citations and references, and annotate them.
 
 <img src="https://github.com/jsobel1/WikiCitationHistoRy/blob/master/img/WikiHistory_logo_V3_test.png" width="250">


### PR DESCRIPTION
## Summary
- run covr::codecov() in CI via new GitHub Actions workflow
- ignore CI config from R builds
- show Codecov coverage badge in README

## Testing
- `R -q -e 'covr::package_coverage()'` *(fails: command not found)*
- `apt-get install -y r-base` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b559fc77488327b23716da139711e3