### PR TITLE
Add mock examples and workflow vignette

### DIFF
--- a/R/WikiHistoRyfunctions.r
+++ b/R/WikiHistoRyfunctions.r
@@ -556,8 +556,8 @@ parse_article_ALL_citations=function(art_text){
 #' @export
 #'
 #' @examples
-#' art_test=get_article_most_recent_table("Zeitgeber")
-#' get_refCount(art_test[9])
+#' text <- "<ref>Example</ref>"
+#' get_refCount(text)
 #'
 
 get_refCount=function(art_text){
@@ -577,8 +577,8 @@ get_refCount=function(art_text){
 #' @export
 #'
 #' @examples
-#' art_test=get_article_most_recent_table("Zeitgeber")
-#' get_urlCount(art_test[9])
+#' text <- "Visit http://example.com"
+#' get_urlCount(text)
 #'
 
 get_urlCount=function(art_text){
@@ -598,8 +598,8 @@ get_urlCount=function(art_text){
 #' @export
 #'
 #' @examples
-#' art_test=get_article_most_recent_table("Zeitgeber")
-#' get_hyperlinkCount(art_test[9])
+#' text <- "[[Link]]"
+#' get_hyperlinkCount(text)
 #'
 
 get_hyperlinkCount=function(art_text){
@@ -620,8 +620,8 @@ get_hyperlinkCount=function(art_text){
 #' @export
 #'
 #' @examples
-#' art_test=get_article_most_recent_table("Zeitgeber")
-#' get_doi_count(art_test[9])
+#' text <- "Reference with DOI 10.1000/xyz123"
+#' get_doi_count(text)
 #'
 
 get_doi_count=function(art_text){
@@ -641,8 +641,8 @@ get_doi_count=function(art_text){
 #' @export
 #'
 #' @examples
-#' art_test=get_article_most_recent_table("Zeitgeber")
-#' get_ISBN_count(art_test[9])
+#' text <- "ISBN 978-3-16-148410-0 mentioned"
+#' get_ISBN_count(text)
 #'
 
 get_ISBN_count=function(art_text){
@@ -663,8 +663,8 @@ get_ISBN_count=function(art_text){
 #' @export
 #'
 #' @examples
-#' art_test=get_article_most_recent_table("Zeitgeber")
-#' get_anyCount(art_test[9],'<ref.*?</ref>')
+#' text <- "<ref>Example</ref>"
+#' get_anyCount(text,'<ref.*?</ref>')
 #'
 
  get_anyCount=function(art_text,regexp){

--- a/man/get_ISBN_count.Rd
+++ b/man/get_ISBN_count.Rd
@@ -17,7 +17,7 @@ This function get a wikipedia article content
 and return ISBN count
 }
 \examples{
-art_test=get_article_most_recent_table("Zeitgeber")
-get_ISBN_count(art_test[9])
+ text <- "ISBN 978-3-16-148410-0 mentioned"
+ get_ISBN_count(text)
 
 }

--- a/man/get_anyCount.Rd
+++ b/man/get_anyCount.Rd
@@ -19,7 +19,7 @@ This function get a wikipedia article content and a regular expression as argume
 and return regex count in the text.
 }
 \examples{
-art_test=get_article_most_recent_table("Zeitgeber")
-get_anyCount(art_test[9],'<ref.*?</ref>')
+ text <- "<ref>Example</ref>"
+ get_anyCount(text,'<ref.*?</ref>')
 
 }

--- a/man/get_doi_count.Rd
+++ b/man/get_doi_count.Rd
@@ -17,7 +17,7 @@ This function get a wikipedia article content
 and return doi count
 }
 \examples{
-art_test=get_article_most_recent_table("Zeitgeber")
-get_doi_count(art_test[9])
+ text <- "Reference with DOI 10.1000/xyz123"
+ get_doi_count(text)
 
 }

--- a/man/get_hyperlinkCount.Rd
+++ b/man/get_hyperlinkCount.Rd
@@ -17,7 +17,7 @@ This function get a wikipedia article content
 and return hyperlinkCount
 }
 \examples{
-art_test=get_article_most_recent_table("Zeitgeber")
-get_hyperlinkCount(art_test[9])
+ text <- "[[Link]]"
+ get_hyperlinkCount(text)
 
 }

--- a/man/get_refCount.Rd
+++ b/man/get_refCount.Rd
@@ -17,7 +17,7 @@ This function get a wikipedia article content
 and return refCount
 }
 \examples{
-art_test=get_article_most_recent_table("Zeitgeber")
-get_refCount(art_test[9])
+ text <- "<ref>Example</ref>"
+ get_refCount(text)
 
 }

--- a/man/get_urlCount.Rd
+++ b/man/get_urlCount.Rd
@@ -17,7 +17,7 @@ This function get a wikipedia article content
 and return urlCount
 }
 \examples{
-art_test=get_article_most_recent_table("Zeitgeber")
-get_urlCount(art_test[9])
+ text <- "Visit http://example.com"
+ get_urlCount(text)
 
 }

--- a/vignettes/workflow.Rmd
+++ b/vignettes/workflow.Rmd
@@ -1,0 +1,48 @@
+---
+title: "Workflow example"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Workflow example}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+library(WikiCitationHistoRy)
+```
+
+## Retrieve article history
+
+```{r}
+mock_history <- data.frame(
+  art = "Demo",
+  revid = 1:2,
+  parentid = c(NA,1),
+  user = c("u1","u2"),
+  userid = c(1,2),
+  timestamp = c("2020-01-01","2020-02-01"),
+  size = c(100,110),
+  comment = c("init","update"),
+  `*` = c(
+    "Initial text with doi 10.1000/xyz123",
+    "Updated text with <ref>{{cite web|url=http://example.com}}</ref>"
+  )
+)
+mock_history
+```
+
+## Parse citations
+
+```{r}
+citations <- get_regex_citations_in_wiki_table(mock_history, pkg.env$doi_regexp)
+citations
+```
+
+## Aggregate metrics
+
+```{r}
+refCount <- get_refCount(mock_history$`*`[2])
+urlCount <- get_urlCount(mock_history$`*`[2])
+refCount
+urlCount
+```


### PR DESCRIPTION
## Summary
- replace non-executable examples with small mock text snippets
- add a workflow vignette demonstrating history retrieval, citation parsing, and metric aggregation

## Testing
- `devtools::document()` *(fails: missing packages "textreuse", "xlsx", "rJava", "WikipediR", "rcrossref", "timevis", "europepmc", and "textclean")*
- `devtools::build_vignettes()`
- `R CMD check --as-cran .` *(fails: Required fields missing or empty: 'Author' 'Maintainer')*

------
https://chatgpt.com/codex/tasks/task_e_68b559e7c2648327bff753dfa4f24b9a