### PR TITLE
Add testthat infrastructure and unit tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,3 +35,6 @@ Imports:
 	europepmc,
 	textclean
 RoxygenNote: 7.3.1
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(WikiCitationHistoRy)
+
+test_check("WikiCitationHistoRy")

--- a/tests/testthat/helper-mock_api.R
+++ b/tests/testthat/helper-mock_api.R
@@ -1,0 +1,11 @@
+library(httr)
+library(stringr)
+with_mock_api <- function(response_body, expr) {
+  code <- substitute(expr)
+  testthat::with_mocked_bindings(
+    eval(code, parent.frame()),
+    GET = function(url, ...) list(url = url),
+    content = function(response, type = NULL, encoding = "UTF-8", ...) response_body,
+    .package = "httr"
+  )
+}

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -1,0 +1,7 @@
+test_that("get_article_info_table parses mocked response", {
+  json <- '{"batchcomplete":"","query":{"pages":{"123":{"pageid":123,"title":"Foo","length":456}}}}'
+  result <- with_mock_api(json, get_article_info_table("Foo"))
+  expect_equal(as.numeric(result[["pageid"]]), 123)
+  expect_equal(result[["title"]], "Foo")
+  expect_equal(as.numeric(result[["length"]]), 456)
+})

--- a/tests/testthat/test-parsing.R
+++ b/tests/testthat/test-parsing.R
@@ -1,0 +1,24 @@
+test_that("parse_cite_type extracts type", {
+  expect_equal(parse_cite_type("{{cite journal|title=Example}}"), "journal")
+  expect_equal(parse_cite_type("{{Cite book|title=Book}}"), "book")
+})
+
+test_that("extract_citations finds citations", {
+  text <- "Intro {{Cite journal|title=Foo}} middle {{cite web|url=http://example.com}} end"
+  cites <- extract_citations(text)
+  expect_equal(cites, c("{{Cite journal|title=Foo}}", "{{cite web|url=http://example.com}}"))
+})
+
+test_that("Get_sci_score2 counts DOI over refs", {
+  text <- "<ref>{{Cite journal|doi=10.1234/abcd}}</ref><ref>{{Cite book|title=Book}}</ref>"
+  expect_equal(Get_sci_score2(text), 0.5)
+})
+
+test_that("Get_source_type_counts counts citation types", {
+  text <- "{{cite journal|title=Foo}} {{cite book|title=Bar}} {{cite journal|title=Baz}}"
+  counts <- Get_source_type_counts(text)
+  journal <- counts$Freq[counts$cite_type == "journal"]
+  book <- counts$Freq[counts$cite_type == "book"]
+  expect_equal(journal, 2)
+  expect_equal(book, 1)
+})


### PR DESCRIPTION
## Summary
- scaffold testthat setup and enable edition 3
- add unit tests for citation parsing and counting helpers
- mock HTTP requests for `get_article_info_table`

## Testing
- `R -q -e 'source("R/WikiHistoRyfunctions.r"); testthat::test_dir("tests/testthat")'`


------
https://chatgpt.com/codex/tasks/task_e_68b559dd416c8327b8a138c5060e0bb1